### PR TITLE
Speed up page by about 700%

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,1 +1,13 @@
-noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off mitigations=off
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="robots" content="index, follow">
+<meta name="description" content="noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off mitigations=off">
+<meta property="og:description" content="noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off mitigations=off">
+<meta name="twitter:description" content="noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off mitigations=off">
+<style>code{font-family:Consolas,"SF Mono",Menlo,"Ubuntu Mono",monospace}</style>
+</head>
+<body><code>noibrs noibpb nopti nospectre_v2 nospectre_v1 l1tf=off nospec_store_bypass_disable no_stf_barrier mds=off mitigations=off</code></body>
+</html>


### PR DESCRIPTION
It's happened to everyone: you're halfway climbing up Mount Everest, all you have with you is a smartphone and climbing gear. You've just ssh'd into a desktop computer from the phone and you're ready to add these kernel options. But the website is all zoomed out on your phone, and the cold of the mountain make it impossible to pinch-to-zoom to see the text.
Gone are those days! Not having to zoom in on phones is likely to increase content viewing speed by about 200% alone.

Sometimes you're just looking at kernel parameters from Internet Explorer, and it shows a bunch of gibberish because IE cannot display much more than the letters A-Z without the website specifying it's utf-8.
Gone are those days!

Imagine going to websites anymore. The entire content is now directly copiable from links in chat apps and social media. Estimated content viewing speed increase: ~500%.

https://news.ycombinator.com/item?id=19942042 you said PRs accepted, and nobody followed up..